### PR TITLE
Add preproc_sequence

### DIFF
--- a/preproc_sequence.schema
+++ b/preproc_sequence.schema
@@ -1,0 +1,3 @@
+create_table "preproc_sequence", primary_key: "id", force: :cascade do |t|
+  t.bigint     "value",     null: false
+end

--- a/preproc_sequence.schema
+++ b/preproc_sequence.schema
@@ -1,3 +1,1 @@
-create_table "preproc_sequence", primary_key: "id", force: :cascade do |t|
-  t.bigint     "value",     null: false
-end
+execute("create sequence if not exists preproc_sequence increment 10000 start with 0 minvalue 0")

--- a/preproc_sequence.schema
+++ b/preproc_sequence.schema
@@ -1,1 +1,0 @@
-execute("create sequence if not exists preproc_sequence increment 10000 start with 0 minvalue 0")

--- a/strload_sequence.schema
+++ b/strload_sequence.schema
@@ -1,0 +1,1 @@
+execute("create sequence if not exists strload_sequence increment 10000 start with 0 minvalue 0")


### PR DESCRIPTION
連番 Op を preproc に実装するため、連番を保持するテーブルを作ります。
一応複数のカウンタを持てるようにするために `id` カラムがあります。