### PR TITLE
strload_stream_bundles: add columns: dest_bucket, dest_prefix

### DIFF
--- a/strload_stream_bundles.schema
+++ b/strload_stream_bundles.schema
@@ -2,6 +2,8 @@ create_table "strload_stream_bundles", primary_key: "stream_bundle_id", force: :
   t.integer "stream_id", null: false
   t.text    "s3_bucket", null: false
   t.text    "s3_prefix", null: false
+  t.text    "dest_bucket", null: false
+  t.text    "dest_prefix", null: false
 end
 
 add_index "strload_stream_bundles", ["stream_id"], name: "strload_stream_bundles_stream_id_idx", using: :btree


### PR DESCRIPTION
Saves dest S3 bucket and prefix to strload_stream_bundles to keep all routing information.