### PR TITLE
New table strload_columns

### DIFF
--- a/strload_columns.schema
+++ b/strload_columns.schema
@@ -1,0 +1,12 @@
+create_table "strload_columns", primary_key: "column_id", force: :cascade do |t|
+  t.integer  "stream_id", null: false
+  t.text     "column_name", null: false
+  t.text     "source_name"
+  t.text     "value_type", null: false
+  t.integer  "value_length"
+  t.text     "source_offset"
+  t.text     "zone_offset"
+  t.datetime "create_time", null: false
+end
+
+add_index "strload_columns", ["stream_id"], name: "strload_columns_stream_id_idx", using: :btree

--- a/strload_streams.schema
+++ b/strload_streams.schema
@@ -6,6 +6,7 @@ create_table "strload_streams", primary_key: "stream_id", id: :serial, force: :c
   t.boolean  "no_dispatch", null: false, default: false
   t.boolean  "initialized", null: false, default: false
   t.datetime "create_time", null: false
+  t.boolean  "column_initialized", null: false, default: false
 end
 
 add_index "strload_streams", ["table_id"], name: "strload_streams_table_id_idx", using: :btree


### PR DESCRIPTION
For https://github.com/bricolages/bricolage-streaming-preprocessor/pull/83

カラムの型を記録するためのテーブル strload_columns を追加します。

strload_streams.column_initialized が true のときはこの型情報に基いたクレンジングを有効にします。

@bricolages/all 
