### PR TITLE
strload_columns must be unique for each stream_id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,29 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.4)
-      activesupport (= 5.1.4)
-    activerecord (5.1.4)
-      activemodel (= 5.1.4)
-      activesupport (= 5.1.4)
-      arel (~> 8.0)
-    activesupport (5.1.4)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activerecord (5.2.0)
+      activemodel (= 5.2.0)
+      activesupport (= 5.2.0)
+      arel (>= 9.0)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (8.0.0)
+    arel (9.0.0)
     concurrent-ruby (1.0.5)
     diffy (3.2.0)
-    i18n (0.9.1)
+    i18n (1.0.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     pg (0.18.4)
-    ridgepole (0.7.0)
+    ridgepole (0.7.1)
       activerecord (>= 5.0.1, < 6)
       diffy
     thread_safe (0.3.6)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -34,4 +34,4 @@ DEPENDENCIES
   ridgepole
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/strload_columns.schema
+++ b/strload_columns.schema
@@ -9,4 +9,4 @@ create_table "strload_columns", primary_key: "column_id", force: :cascade do |t|
   t.datetime "create_time", null: false
 end
 
-add_index "strload_columns", ["stream_id"], name: "strload_columns_stream_id_idx", using: :btree
+add_index "strload_columns", ["stream_id", "column_name"], name: "strload_columns_stream_id_column_name_idx", unique: true, using: :btree


### PR DESCRIPTION
ストリーム内においてカラム名はユニークでないとまずいのでunique indexを張ります。

stream_idのみのインデックスは上記のインデックスで代替できるので廃止。

CC @bricolages/all 