### PR TITLE
Add timestamp(partition key or sortkey) column flag

### DIFF
--- a/strload_columns.schema
+++ b/strload_columns.schema
@@ -7,6 +7,7 @@ create_table "strload_columns", primary_key: "column_id", force: :cascade do |t|
   t.text     "source_offset"
   t.text     "zone_offset"
   t.datetime "create_time", null: false
+  t.boolean  "timestamp_column", null: false, default: false
 end
 
 add_index "strload_columns", ["stream_id", "column_name"], name: "strload_columns_stream_id_column_name_idx", unique: true, using: :btree

--- a/strload_columns.schema
+++ b/strload_columns.schema
@@ -7,7 +7,7 @@ create_table "strload_columns", primary_key: "column_id", force: :cascade do |t|
   t.text     "source_offset"
   t.text     "zone_offset"
   t.datetime "create_time", null: false
-  t.boolean  "timestamp_column", null: false, default: false
+  t.boolean  "sortkey_column", null: false, default: false
 end
 
 add_index "strload_columns", ["stream_id", "column_name"], name: "strload_columns_stream_id_column_name_idx", unique: true, using: :btree


### PR DESCRIPTION
ログテーブルの時刻カラムを示すフラグを追加します。
無駄に複雑になるので、constraint とかでは一切縛ってません。
1ストリームに複数の時刻カラムがある場合はアプリケーションコードで弾けばいい、という意図です。