### PR TITLE
Split preproc log table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gem 'ridgepole'
-gem 'pg', '~> 0.18.4'
+gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activerecord (5.2.0)
-      activemodel (= 5.2.0)
-      activesupport (= 5.2.0)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activerecord (5.2.1)
+      activemodel (= 5.2.1)
+      activesupport (= 5.2.1)
       arel (>= 9.0)
-    activesupport (5.2.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
     concurrent-ruby (1.0.5)
-    diffy (3.2.0)
-    i18n (1.0.0)
+    diffy (3.2.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
-    pg (0.18.4)
-    ridgepole (0.7.1)
+    pg (1.0.0)
+    ridgepole (0.7.4)
       activerecord (>= 5.0.1, < 6)
       diffy
     thread_safe (0.3.6)
@@ -30,7 +30,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  pg (~> 0.18.4)
+  pg
   ridgepole
 
 BUNDLED WITH

--- a/strload_chunks.schema
+++ b/strload_chunks.schema
@@ -1,0 +1,15 @@
+create_table "strload_chunks", primary_key: "chunk_id", force: :cascade do |t|
+  t.text "object_url", null: false
+  t.bigint "object_size", null: false, default: 0
+  t.integer "object_rows", null: false, default: 0
+  t.integer "error_rows", null: false, default: 0
+  t.datetime "object_created_time", null: true
+  t.bigint "table_id", null: false
+
+  # filled later
+  t.boolean "dispatched", null: false, default: false
+  t.boolean "loaded", null: false, default: false
+end
+
+add_index "strload_chunks", ["object_url"], name: "strload_chunks_idx_object_url", unique: true, using: :btree
+# create index strload_chunks_idx_not_loaded on strload_chunks (table_id) where dispatched and not loaded;

--- a/strload_packets.schema
+++ b/strload_packets.schema
@@ -1,0 +1,13 @@
+create_table "strload_packets", primary_key: "packet_id", force: :cascade do |t|
+  t.text "object_url", null: false
+  t.integer "object_size", null: false
+  t.datetime "object_created_time", null: true
+  t.bigint "stream_id", null: false
+
+  # filled after preproc is succeeded
+  t.bigint "chunk_id", null: true
+  t.boolean "processed", null: false, default: false
+end
+
+add_index "strload_packets", ["stream_id", "object_created_time"], name: "strload_packets_idx_stream_id_object_created_time", using: :btree
+add_index "strload_packets", ["object_url"], name: "strload_packets_idx_object_url", unique: true, using: :btree

--- a/strload_preproc_jobs.schema
+++ b/strload_preproc_jobs.schema
@@ -1,0 +1,10 @@
+create_table "strload_preproc_jobs", primary_key: "preproc_job_id", force: :cascade do |t|
+  t.bigint "preproc_message_id", null: false
+  t.datetime "start_time", null: false
+  t.datetime "end_time", null: true
+  t.string "status", limit: 8, null: false
+  t.text "message", null: false
+end
+
+add_index "strload_preproc_jobs", ["preproc_message_id", "end_time"], name: "strload_preproc_jobs_idx_preproc_message_id_end_time", using: :btree
+add_index "strload_preproc_jobs", ["start_time"], name: "strload_preproc_jobs_idx_start_time", using: :btree

--- a/strload_preproc_messages.schema
+++ b/strload_preproc_messages.schema
@@ -1,0 +1,12 @@
+create_table "strload_preproc_messages", primary_key: "preproc_message_id", force: :cascade do |t|
+  t.string "message_id", limit: 64, null: false
+  t.datetime "event_time", null: false
+  t.datetime "received_time", null: false
+  t.bigint "packet_id", null: true
+  t.text "object_url", null: false
+  t.boolean "handled", null: false, default: false
+end
+
+add_index "strload_preproc_messages", ["message_id"], name: "strload_preproc_messages_idx_message_id", unique: true, using: :btree
+add_index "strload_preproc_messages", ["object_url"], name: "strload_preproc_messages_idx_object_url", using: :btree
+add_index "strload_preproc_messages", ["event_time"], name: "strload_preproc_messages_idx_event_time", using: :btree


### PR DESCRIPTION
preprocのモニタリング機能向上のため、preproc_logをちゃんと構造化して4つのテーブルに分割します。

- strload_preproc_messages: preproc SQSメッセージをreceiveしてからdeleteするまでのログ。1メッセージ1行（SQS message idがユニーク）
- strload_preproc_jobs: preproc 1処理のログ。1実行につき1行。
- strload_packets: preprocの入力オブジェクトの記録。1オブジェクト1行（S3 URLがユニーク）
- strload_chunks: preprocの出力オブジェクトの記録。1オブジェクト1行（S3 URLがユニーク）

このスキーマ変更で、以下のような処理が可能になります。

- 処理開始前のSQSメッセージがDB上で見られる（いままではpreprocが開始しないと行が残らなかった）
- ストリームごとにSQSメッセージが見られる（未処理も含む）
- ストリームごと・テーブルごとに最近処理されたS3オブジェクトが見られる
- dispatcherがstrload_objectsにinsertしなくてもよくなる（ここはdispatcher側が未対応なので「論理できた」）

@bricolages/all 