### PR TITLE
strload_columns: Moves sortkey_column to the last of column list

### DIFF
--- a/strload_columns.schema
+++ b/strload_columns.schema
@@ -7,8 +7,8 @@ create_table "strload_columns", primary_key: "column_id", force: :cascade do |t|
   t.text     "source_offset"
   t.text     "zone_offset"
   t.datetime "create_time", null: false
-  t.boolean  "sortkey_column", null: false, default: false
   t.boolean  "partition_source", null: false, default: false
+  t.boolean  "sortkey_column", null: false, default: false
 end
 
 add_index "strload_columns", ["stream_id", "column_name"], name: "strload_columns_stream_id_column_name_idx", unique: true, using: :btree


### PR DESCRIPTION
#13 で追加されたsortkey_columnですが、実際にはapplyされていなかった？ のか存在しないので末尾に移動して再追加します