### PR TITLE
Saves table prefix in strload_tables instead of strload_stream_bundles

### DIFF
--- a/strload_stream_bundles.schema
+++ b/strload_stream_bundles.schema
@@ -2,8 +2,6 @@ create_table "strload_stream_bundles", primary_key: "stream_bundle_id", id: :ser
   t.integer "stream_id", null: false
   t.text    "s3_bucket", null: false
   t.text    "s3_prefix", null: false
-  t.text    "dest_bucket", null: false
-  t.text    "dest_prefix", null: false
 end
 
 add_index "strload_stream_bundles", ["stream_id"], name: "strload_stream_bundles_stream_id_idx", using: :btree

--- a/strload_tables.schema
+++ b/strload_tables.schema
@@ -5,6 +5,8 @@ create_table "strload_tables", primary_key: "table_id", id: :serial, force: :cas
   t.integer "load_batch_size",                             null: false
   t.integer "load_interval",                               null: false
   t.boolean "disabled",                    default: false, null: false
+  t.text "s3_bucket", null: false
+  t.text "s3_prefix", null: false
 end
 
 add_index "strload_tables", ["data_source_id"], name: "strload_tables_data_source_id_key", unique: true, using: :btree


### PR DESCRIPTION
chunkのS3 prefixをbundleからtableへ移します

ref https://github.com/bricolages/bricolage-streaming-preprocessor/pull/94